### PR TITLE
Update paper publication status and add ECIO 2026 conference entries

### DIFF
--- a/data/conferences.yml
+++ b/data/conferences.yml
@@ -24,6 +24,22 @@
 #   pdf:       Direct PDF download link
 #   code:      GitHub/Code link
 
+- id: "dimici2026integrated"
+  type: conference
+  title: "Integrated Photonic Computing for Electroencephalography Signal Forecasting"
+  authors: ["Can Dimici", "Ujal Rzayev", "Zeynep İpek Yanmaz", "Bahrem Serhat Danis", "Arda Tuna Vit", "Aycan Deniz Vit", "Enes Akcakoca", "Demet Baldan Desdemir", "Gulzade Polat", "Emir Salih Magden"]
+  venue: "European Conference on Integrated Optics (ECIO) 2026"
+  note: "paper T2C.2"
+  year: "2026"
+
+- id: "rzayev2026spectral"
+  type: conference
+  title: "Spectral Photonic Encoder for Computational Tasks via Optoelectronic Recurrence"
+  authors: ["Ujal Rzayev", "Aras Arslan", "Can Dimici", "Aycan Deniz Vit", "Arda Tuna Vit", "Emir Salih Magden"]
+  venue: "European Conference on Integrated Optics (ECIO) 2026"
+  note: "paper P12.15"
+  year: "2026"
+
 - id: "danis2026learned"
   type: conference
   title: "Learned manifold reparameterization for DRC-compatible inverse design in silicon photonics"

--- a/data/journals.yml
+++ b/data/journals.yml
@@ -52,11 +52,13 @@
   pdf: "https://arxiv.org/pdf/2411.16698.pdf"
 
 - id: danis2026intrinsically
-  type: preprint
-  title: "Intrinsically DRC-Compliant Nanophotonic Design via Learned Generative Manifolds"
+  type: journal
+  title: "Intrinsically Design-Rule-Compliant Nanophotonic Inverse Design via Learned Generative Manifolds"
   authors: ["Bahrem Serhat Danis", "Demet Baldan Desdemir", "Enes Akcakoca", "Zeynep Ipek Yanmaz", "Gulzade Polat", "Ahmet Onur Dasdemir", "Aytug Aydogan", "Abdullah Magden", "Emir Salih Magden"]
-  venue: "arXiv:2602.03142"
+  venue: "Laser & Photonics Reviews"
+  pages: "e71486"
   year: "2026"
+  doi: "https://doi.org/10.1002/lpor.71486"
   preprint: "https://arxiv.org/abs/2602.03142"
   pdf: "https://arxiv.org/pdf/2602.03142"
   code: "https://github.com/Photonic-Architecture-Laboratories/drcgenerator"
@@ -336,8 +338,8 @@
   year: "2023"
   publisher: "IEEE"
   doi: "https://ieeexplore.ieee.org/document/10056840"
-  preprint: "https://arxiv.org/abs/2303.05729"
-  pdf: "https://arxiv.org/pdf/2303.05729"
+  preprint: "https://arxiv.org/abs/2209.08620"
+  pdf: "https://arxiv.org/pdf/2209.08620"
 
 - id: "dasdemir2023computational"
   type: journal


### PR DESCRIPTION
Promote the DRC-compliant nanophotonic design paper from preprint to its published Laser & Photonics Reviews entry, fix the arXiv link for the ultra-broadband filters paper, and add two new ECIO 2026 conference presentations.